### PR TITLE
Increase memory request/limit for RBAC agent

### DIFF
--- a/stable/suse-observability-agent/README.md
+++ b/stable/suse-observability-agent/README.md
@@ -181,8 +181,8 @@ stackstate/suse-observability-agent
 | kubernetes-rbac-agent.containers.rbacAgent.podAnnotations | object | `{}` | Additional annotations on the pod |
 | kubernetes-rbac-agent.containers.rbacAgent.podLabels | object | `{}` | Additional labels on the pod |
 | kubernetes-rbac-agent.containers.rbacAgent.priorityClassName | string | `""` | Set priorityClassName |
-| kubernetes-rbac-agent.containers.rbacAgent.resources.limits.memory | string | `"40Mi"` | Memory resource limits. |
-| kubernetes-rbac-agent.containers.rbacAgent.resources.requests.memory | string | `"25Mi"` | Memory resource requests. |
+| kubernetes-rbac-agent.containers.rbacAgent.resources.limits.memory | string | `"256Mi"` | Memory resource limits. |
+| kubernetes-rbac-agent.containers.rbacAgent.resources.requests.memory | string | `"128Mi"` | Memory resource requests. |
 | kubernetes-rbac-agent.containers.rbacAgent.tolerations | list | `[]` | Set tolerations |
 | kubernetes-rbac-agent.enabled | bool | `true` |  |
 | kubernetes-rbac-agent.roleType | string | `"scope"` |  |

--- a/stable/suse-observability-agent/values.yaml
+++ b/stable/suse-observability-agent/values.yaml
@@ -725,10 +725,10 @@ kubernetes-rbac-agent:
       resources:
         requests:
           # kubernetes-rbac-agent.containers.rbacAgent.resources.requests.memory -- Memory resource requests.
-          memory: "25Mi"
+          memory: "128Mi"
         limits:
           # kubernetes-rbac-agent.containers.rbacAgent.resources.limits.memory -- Memory resource limits.
-          memory: "40Mi"
+          memory: "256Mi"
       # kubernetes-rbac-agent.containers.rbacAgent.env -- Additional environment variables
       env: {}
       # kubernetes-rbac-agent.containers.rbacAgent.podLabels -- Additional labels on the pod


### PR DESCRIPTION
SURE-11446

There have been errors relating to OOMKilled on suse-observability-agent-rbac-agent pod, increasing this memory to more reasonable numbers 