### PR TITLE
STAC-25069 Cutover: bump suse-observability-agent to 3.78.2 (agent ta…

### DIFF
--- a/stable/suse-observability-agent/Chart.yaml
+++ b/stable/suse-observability-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 3.71.2
-version: 1.4.0
+appVersion: 3.78.2
+version: 1.4.1
 description: Helm chart for the SUSE observability Agent.
 keywords:
 - monitoring

--- a/stable/suse-observability-agent/README.md
+++ b/stable/suse-observability-agent/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for the SUSE observability Agent.
 
-Current chart version is `1.4.0`
+Current chart version is `1.4.1`
 
 **Homepage:** <https://github.com/StackVista/suse-observability-agent>
 
@@ -95,7 +95,7 @@ Overlays use map-shaped values, so combining multiple overlays (or layering them
 | checksAgent.enabled | bool | `true` | Enable / disable runnning cluster checks in a separately deployed pod |
 | checksAgent.image.pullPolicy | string | `"IfNotPresent"` | Default container image pull policy. |
 | checksAgent.image.repository | string | `"stackstate/stackstate-k8s-agent"` | Base container image repository. |
-| checksAgent.image.tag | string | `"e1076c57"` | Default container image tag. |
+| checksAgent.image.tag | string | `"4b3a88a5"` | Default container image tag. |
 | checksAgent.livenessProbe.enabled | bool | `true` | Enable use of livenessProbe check. |
 | checksAgent.livenessProbe.failureThreshold | int | `3` | `failureThreshold` for the liveness probe. |
 | checksAgent.livenessProbe.initialDelaySeconds | int | `15` | `initialDelaySeconds` for the liveness probe. |
@@ -157,7 +157,7 @@ Overlays use map-shaped values, so combining multiple overlays (or layering them
 | clusterAgent.enabled | bool | `true` | Enable / disable the cluster agent. |
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Default container image pull policy. |
 | clusterAgent.image.repository | string | `"stackstate/stackstate-k8s-cluster-agent"` | Base container image repository. |
-| clusterAgent.image.tag | string | `"e1076c57"` | Default container image tag. |
+| clusterAgent.image.tag | string | `"4b3a88a5"` | Default container image tag. |
 | clusterAgent.livenessProbe.enabled | bool | `true` | Enable use of livenessProbe check. |
 | clusterAgent.livenessProbe.failureThreshold | int | `3` | `failureThreshold` for the liveness probe. |
 | clusterAgent.livenessProbe.initialDelaySeconds | int | `15` | `initialDelaySeconds` for the liveness probe. |
@@ -300,7 +300,7 @@ Overlays use map-shaped values, so combining multiple overlays (or layering them
 | nodeAgent.containers.agent.env | object | `{}` | Additional environment variables for the agent container |
 | nodeAgent.containers.agent.image.pullPolicy | string | `"IfNotPresent"` | Default container image pull policy. |
 | nodeAgent.containers.agent.image.repository | string | `"stackstate/stackstate-k8s-agent"` | Base container image repository. |
-| nodeAgent.containers.agent.image.tag | string | `"e1076c57"` | Default container image tag. |
+| nodeAgent.containers.agent.image.tag | string | `"4b3a88a5"` | Default container image tag. |
 | nodeAgent.containers.agent.livenessProbe.enabled | bool | `true` | Enable use of livenessProbe check. |
 | nodeAgent.containers.agent.livenessProbe.failureThreshold | int | `3` | `failureThreshold` for the liveness probe. |
 | nodeAgent.containers.agent.livenessProbe.initialDelaySeconds | int | `15` | `initialDelaySeconds` for the liveness probe. |

--- a/stable/suse-observability-agent/values.yaml
+++ b/stable/suse-observability-agent/values.yaml
@@ -162,7 +162,7 @@ nodeAgent:
         # nodeAgent.containers.agent.image.repository -- Base container image repository.
         repository: stackstate/stackstate-k8s-agent
         # nodeAgent.containers.agent.image.tag -- Default container image tag.
-        tag: e1076c57
+        tag: 4b3a88a5
         # nodeAgent.containers.agent.image.pullPolicy -- Default container image pull policy.
         pullPolicy: IfNotPresent
       # nodeAgent.containers.agent.env -- Additional environment variables for the agent container
@@ -450,7 +450,7 @@ clusterAgent:
     # clusterAgent.image.repository -- Base container image repository.
     repository: stackstate/stackstate-k8s-cluster-agent
     # clusterAgent.image.tag -- Default container image tag.
-    tag: e1076c57
+    tag: 4b3a88a5
     # clusterAgent.image.pullPolicy -- Default container image pull policy.
     pullPolicy: IfNotPresent
 
@@ -593,7 +593,7 @@ checksAgent:
     # checksAgent.image.repository -- Base container image repository.
     repository: stackstate/stackstate-k8s-agent
     # checksAgent.image.tag -- Default container image tag.
-    tag: e1076c57
+    tag: 4b3a88a5
     # checksAgent.image.pullPolicy -- Default container image pull policy.
     pullPolicy: IfNotPresent
 

--- a/updatecli/updatecli.d/update-docker-images/update.yaml
+++ b/updatecli/updatecli.d/update-docker-images/update.yaml
@@ -257,7 +257,7 @@ sources:
     kind: shell
     spec:
       command: |
-        curl -sf "https://api.github.com/repos/StackVista/stackstate-agent/commits/stackstate-7.71.2" | jq -r '.sha[0:8]'
+        curl -sf "https://api.github.com/repos/StackVista/stackstate-agent/commits/stackstate-7.78.2" | jq -r '.sha[0:8]'
 
 # Single pipeline: each target reads from its own sourceid.
 # All suse-observability subchart image tags are in stable/suse-observability/values.yaml


### PR DESCRIPTION
…g 4b3a88a5).

Pairs with the agent fork's main branch flip from stackstate-7.71.2 to stackstate-7.78.2 (the DD 7.71.2 -> 7.78.2 upstream merge cutover).

Chart.yaml:
- appVersion 3.71.2 -> 3.78.2 (convention: <STS-major>.<DD-minor>.<DD-patch>)
- version    1.3.50 -> 1.3.51

values.yaml (3 sites, all the same agent image, identical tag bumps):
- nodeAgent.containers.agent.image.tag     cb4d9ce2 -> 4b3a88a5
- clusterAgent.image.tag                   cb4d9ce2 -> 4b3a88a5
- checksAgent.image.tag                    cb4d9ce2 -> 4b3a88a5

4b3a88a5 is the latest stackstate-7.78.2 branch build of stackstate-agent.

Left intact (separate cadences per UPSTREAM_MERGE.md):
- nodeAgent.containers.processAgent.image.tag (f1075fdf)
- logsAgent.image.tag (promtail 3.6.11-so1)

Audits clean:
- No deprecated STS_PROCESS_AGENT_ENABLED env var in _container-agent.yaml or checks-agent-deployment.yaml — only the granular STS_PROCESS_CONFIG_* replacements remain.
- nodes/stats RBAC entry present in node-agent-clusterrole.yaml.

README.md regenerated by helm-docs pre-commit hook (version badge + tag table reflections only).